### PR TITLE
Added reserved=true for Linux app service plans

### DIFF
--- a/webapps.tf
+++ b/webapps.tf
@@ -20,6 +20,7 @@ resource "azurerm_app_service_plan" "free" {
     tags                = "${azurerm_resource_group.webapps.tags}"
 
     kind                = "Linux"
+    reserved            = true
     sku {
         tier = "Free"
         size = "F1"


### PR DESCRIPTION
Refer https://github.com/azurecitadel/azurecitadel.github.io/pull/69 for the doc change. Basically we need to add `reserved=true` for any `Linux `app service plans